### PR TITLE
remove bashisms;

### DIFF
--- a/classes/npm-base.bbclass
+++ b/classes/npm-base.bbclass
@@ -40,7 +40,7 @@ oe_runnpm() {
     mkdir -p "${NPM_HOME_DIR}"
 
     export NPM_VERSION="$(${NPM} --v)"
-    export NPM_CACHE_CMD="clean"
+    export NPM_CACHE_CMD="clean --force"
 
     if [ "${NPM_CACHE_DIR}" = "" ]; then
         export NPM_CONFIG_CACHE="${DL_DIR}/npm_v${NPM_VERSION}_${TARGET_ARCH}_cache/${PF}"
@@ -106,7 +106,7 @@ oe_runnpm_native() {
     mkdir -p "${NPM_HOME_DIR_NATIVE}"
 
     export NPM_VERSION="$(${NPM} --v)"
-    export NPM_CACHE_CMD="clean"
+    export NPM_CACHE_CMD="clean --force"
 
     if [ "${NPM_CACHE_DIR_NATIVE}" = "" ]; then
         export NPM_CONFIG_CACHE="${DL_DIR}/npm_v${NPM_VERSION}_${TARGET_ARCH}_native/${PF}"

--- a/classes/npm-base.bbclass
+++ b/classes/npm-base.bbclass
@@ -42,7 +42,7 @@ oe_runnpm() {
     export NPM_VERSION="$(${NPM} --v)"
     export NPM_CACHE_CMD="clean"
 
-    if [ "${NPM_CACHE_DIR}" == "" ]; then
+    if [ "${NPM_CACHE_DIR}" = "" ]; then
         export NPM_CONFIG_CACHE="${DL_DIR}/npm_v${NPM_VERSION}_${TARGET_ARCH}_cache/${PF}"
     else
         export NPM_CONFIG_CACHE=${NPM_CACHE_DIR}
@@ -108,7 +108,7 @@ oe_runnpm_native() {
     export NPM_VERSION="$(${NPM} --v)"
     export NPM_CACHE_CMD="clean"
 
-    if [ "${NPM_CACHE_DIR_NATIVE}" == "" ]; then
+    if [ "${NPM_CACHE_DIR_NATIVE}" = "" ]; then
         export NPM_CONFIG_CACHE="${DL_DIR}/npm_v${NPM_VERSION}_${TARGET_ARCH}_native/${PF}"
     else
         export NPM_CONFIG_CACHE=${NPM_CACHE_DIR_NATIVE}


### PR DESCRIPTION
This fixed a compilation issue on `thud`.

`/home/build/xyz/build/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/neon-wallet-1.0.0/1.0-r18/temp/run.do_install.1764: 158: [: unexpected operator`

Edit: also an issue where newer `npm` needs `--force` appended to `npm cache clean` command, otherwise fails.