### PR TITLE
Node.js: Add node 12 and npm 6.9.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ OpenEmbedded layer for latest [Node.js](https://nodejs.org/ "Node.js") releases.
  * ![Maintenance LTS 8](https://img.shields.io/badge/Node.js%20Maintenance-8.11.2-B0C4DE.svg)
  * ![Maintenance LTS 6](https://img.shields.io/badge/Node.js%20Maintenance-6.13.1-B0C4DE.svg)
  * ![End of life 7](https://img.shields.io/badge/Node.js%20End%20of%20Life-7.10.1-lightgray.svg)
-
-![LTS Schedule]()
+## LTS Schedule
 <p><img src="https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true" alt="LTS Schedule"/></p>
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ OpenEmbedded layer for latest [Node.js](https://nodejs.org/ "Node.js") releases.
 
 ## Node.js releases
 
+ * ![Current 12](https://img.shields.io/badge/Node.js%20Current-12.0.0-green.svg)
  * ![Current 11](https://img.shields.io/badge/Node.js%20Current-11.14.0-green.svg)
  * ![Active LTS 10](https://img.shields.io/badge/Node.js%20LTS-10.15.3-blue.svg)
  * ![Maintenance LTS 8](https://img.shields.io/badge/Node.js%20Maintenance-8.11.2-B0C4DE.svg)
  * ![Maintenance LTS 6](https://img.shields.io/badge/Node.js%20Maintenance-6.13.1-B0C4DE.svg)
  * ![End of life 7](https://img.shields.io/badge/Node.js%20End%20of%20Life-7.10.1-lightgray.svg)
 
-![LTS Schedule](https://github.com/nodejs/LTS/raw/master/schedule.png)
+![LTS Schedule]()
+<p><img src="https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true" alt="LTS Schedule"/></p>
 
 ## Dependencies
 

--- a/recipes-devtools/nodejs/nodejs_12.0.0.bb
+++ b/recipes-devtools/nodejs/nodejs_12.0.0.bb
@@ -1,0 +1,9 @@
+require nodejs_12.inc
+
+INC_PR = "r1"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2aea9cf46d683635190276ab20e13cfe"
+
+SRC_URI[src.md5sum] = "74bdcc5d80110e385e3876f681656f97"
+SRC_URI[src.sha256sum] = "ef7a25d25370a0c618d50ea72f2e78b8777e015160694d7b7cac05188cc0db65"
+

--- a/recipes-devtools/nodejs/nodejs_12.inc
+++ b/recipes-devtools/nodejs/nodejs_12.inc
@@ -1,0 +1,96 @@
+DESCRIPTION = "Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine"
+HOMEPAGE = "http://nodejs.org"
+
+LICENSE = "MIT"
+
+COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
+# COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
+COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
+
+INC_PR = "r1"
+PR = "${INC_PR}.4"
+
+PROVIDES = "node"
+RPROVIDES_${PN} = "node"
+
+SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src"
+
+S = "${WORKDIR}/node-v${PV}"
+
+# v8 errors out if you have set CCACHE
+CCACHE = ""
+
+inherit nodejs-arch
+
+ARCHFLAGS_arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
+                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
+                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
+                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
+                    '--with-arm-fpu=vfp', d), d), d)}"
+ARCHFLAGS ?= ""
+
+CROSSCONF = "--cross-compiling"
+CROSSCONF_virtclass-native ="--no-cross-compiling"
+
+GYP_DEFINES_append_mipsel = " mips_arch_variant='r1' "
+
+PACKAGECONFIG ??= "zlib openssl"
+
+PACKAGECONFIG[zlib] = "--shared-zlib,,zlib,"
+PACKAGECONFIG[openssl] = "--shared-openssl,,openssl,"
+PACKAGECONFIG[v8-inspector] = "--with-intl=small-icu,--without-inspector --with-intl=none,,"
+
+DISABLE_STATIC = ""
+
+export CXX_host = "${BUILD_CXX}"
+export CC_host = "${BUILD_CC}"
+export CXXFLAGS_host = "${BUILD_CXXFLAGS}"
+export CFLAGS_host = "${BUILD_CFLAGS}"
+
+do_configure () {
+  GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
+  ./configure --prefix="${prefix}" \
+    --dest-cpu="${@nodejs_map_dest_cpu(d.getVar('TARGET_ARCH', True), d)}" \
+    --dest-os=linux ${ARCHFLAGS} \
+    ${CROSSCONF} \
+    ${PACKAGECONFIG_CONFARGS}
+}
+
+do_compile () {
+  oe_runmake BUILDTYPE=Release
+}
+
+do_install () {
+  oe_runmake install DESTDIR="${D}"
+}
+
+do_install_append_class-native() {
+  # make sure we use node from PATH instead of absolute path to sysroot
+  sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+}
+
+do_install_append_class-nativesdk() {
+  # make sure we use node from PATH instead of absolute path to sysroot
+  sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+  sed "1s^.*^#\!/usr/bin/env python^g" -i ${D}${exec_prefix}/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples
+}
+
+do_install_append_class-target() {
+  # make sure we use node from PATH instead of absolute path to sysroot
+  sed "1s^.*^#\!${bindir}/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+}
+
+PACKAGES =+ "${PN}-npm"
+FILES_${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm"
+RDEPENDS_${PN}-npm = "bash python-compiler python-shell python-datetime python-subprocess python-multiprocessing python-crypt python-textutils python-netclient python-misc"
+
+PACKAGES =+ "${PN}-dtrace"
+FILES_${PN}-dtrace = "${exec_prefix}/lib/dtrace"
+
+PACKAGES =+ "${PN}-systemtap"
+FILES_${PN}-systemtap = "${datadir}/systemtap"
+
+INSANE_SKIP_${PN} += "file-rdeps"
+INSANE_SKIP_${PN}-dbg += "host-user-contaminated"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
- Added support Node.js 12.0.0
- npm version 6.9.0
- LTS Schedule diagram link updated (sanitized svg)
- **Note**: patches no-registry are not required anymore since npm 6.6.0.
  > npm-registry-client removed https://github.com/npm/cli/commit/ec9fcc14f4e0e2f3967e2fd6ad8b8433076393cb