### PR TITLE
Order npm_audit after npm_shrinkwrap.

### DIFF
--- a/classes/npm-install.bbclass
+++ b/classes/npm-install.bbclass
@@ -34,4 +34,4 @@ INSANE_SKIP_${PN}-dbg += " host-user-contaminated"
 addtask npm_install after do_compile before do_npm_dedupe
 addtask npm_shrinkwrap after do_npm_install before do_npm_dedupe
 addtask npm_dedupe after do_npm_shrinkwrap before do_install
-addtask npm_audit after do_npm_install before do_npm_dedupe
+addtask npm_audit after do_npm_shrinkwrap before do_npm_dedupe


### PR DESCRIPTION
With the previous ordering, the `do_npm_audit` task could run concurrently with the `do_npm_shrinkwrap` task which can cause failures if relying on the shrinkwrap task to generate the `package-lock.json`. Re-running `do_npm_audit` after the `do_npm_shrinkwrap` builds successfully.